### PR TITLE
[GH-18] Dummy 데이터 반환, 불필요 API 제외

### DIFF
--- a/webtoon-api/src/main/kotlin/com/depromeet/webtoon/api/endpoint/MainController.kt
+++ b/webtoon-api/src/main/kotlin/com/depromeet/webtoon/api/endpoint/MainController.kt
@@ -2,8 +2,10 @@ package com.depromeet.webtoon.api.endpoint
 
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
+import springfox.documentation.annotations.ApiIgnore
 
 @RestController
+@ApiIgnore
 class MainController {
     @GetMapping("/")
     fun root(): Map<String, String> {

--- a/webtoon-api/src/main/kotlin/com/depromeet/webtoon/api/endpoint/author/AuthorController.kt
+++ b/webtoon-api/src/main/kotlin/com/depromeet/webtoon/api/endpoint/author/AuthorController.kt
@@ -1,8 +1,8 @@
 package com.depromeet.webtoon.api.endpoint.author
 
-import com.depromeet.webtoon.core.domain.author.service.AuthorService
 import com.depromeet.webtoon.core.domain.author.dto.AuthorCreateRequestDto
 import com.depromeet.webtoon.core.domain.author.dto.AuthorCreateResponseDto
+import com.depromeet.webtoon.core.domain.author.service.AuthorService
 import com.depromeet.webtoon.core.exceptions.ApiValidationException
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -12,8 +12,10 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
+import springfox.documentation.annotations.ApiIgnore
 
 @RestController
+@ApiIgnore
 class AuthorController(@Autowired val authorService: AuthorService) {
 
     private val log = LoggerFactory.getLogger(AuthorController::class.java)

--- a/webtoon-api/src/main/kotlin/com/depromeet/webtoon/api/endpoint/dto/WeekdayWebtoonsResponse.kt
+++ b/webtoon-api/src/main/kotlin/com/depromeet/webtoon/api/endpoint/dto/WeekdayWebtoonsResponse.kt
@@ -9,5 +9,20 @@ data class WeekdayWebtoonsResponse(
 
 data class Site(
     val site: WebtoonSite,
-    val thumbnail: String
-)
+    val thumbnail: String = site.thumbnail
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Site
+
+        if (site != other.site) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return site.hashCode()
+    }
+}

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/application/imports/dto/WebtoonImportRequest.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/application/imports/dto/WebtoonImportRequest.kt
@@ -1,13 +1,14 @@
 package com.depromeet.webtoon.core.application.imports.dto
 
 import com.depromeet.webtoon.core.type.WebtoonSite
+import com.depromeet.webtoon.core.type.WeekDay
 import java.time.DayOfWeek
 
 data class WebtoonImportRequest(
     val title: String,
     val url: String,
     val thumbnailImage: String,
-    val dayOfWeeks: List<DayOfWeek>,
+    val dayOfWeeks: List<WeekDay>,
     val authors: List<String>,
     val site: WebtoonSite,
     val genres: List<String>,

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/crawl/daum/DaumCrawlerService.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/crawl/daum/DaumCrawlerService.kt
@@ -6,6 +6,7 @@ import com.depromeet.webtoon.core.crawl.daum.dto.webtoondetail.DaumWebtoonDetail
 import com.depromeet.webtoon.core.crawl.daum.dto.webtoondetail.WebtoonWeeks
 import com.depromeet.webtoon.core.crawl.daum.dto.webtoonlist.DaumWebtoonCrawlResult
 import com.depromeet.webtoon.core.type.WebtoonSite
+import com.depromeet.webtoon.core.type.WeekDay
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -48,16 +49,16 @@ class DaumCrawlerService(
             popular: Int
         ): WebtoonImportRequest {
 
-            fun setDayOfWeek(list: List<WebtoonWeeks>): List<DayOfWeek> {
-                val dayOfWeeks = ArrayList<DayOfWeek>()
+            fun setDayOfWeek(list: List<WebtoonWeeks>): List<WeekDay> {
+                val dayOfWeeks = ArrayList<WeekDay>()
                 list.forEach {
-                    if (it.weekDay == "mon") dayOfWeeks.add(DayOfWeek.MONDAY)
-                    if (it.weekDay == "tue") dayOfWeeks.add(DayOfWeek.TUESDAY)
-                    if (it.weekDay == "wed") dayOfWeeks.add(DayOfWeek.WEDNESDAY)
-                    if (it.weekDay == "thu") dayOfWeeks.add(DayOfWeek.THURSDAY)
-                    if (it.weekDay == "fri") dayOfWeeks.add(DayOfWeek.FRIDAY)
-                    if (it.weekDay == "sat") dayOfWeeks.add(DayOfWeek.SATURDAY)
-                    if (it.weekDay == "sun") dayOfWeeks.add(DayOfWeek.SUNDAY)
+                    if (it.weekDay == "mon") dayOfWeeks.add(WeekDay.MON)
+                    if (it.weekDay == "tue") dayOfWeeks.add(WeekDay.TUE)
+                    if (it.weekDay == "wed") dayOfWeeks.add(WeekDay.WED)
+                    if (it.weekDay == "thu") dayOfWeeks.add(WeekDay.THU)
+                    if (it.weekDay == "fri") dayOfWeeks.add(WeekDay.FRI)
+                    if (it.weekDay == "sat") dayOfWeeks.add(WeekDay.SAT)
+                    if (it.weekDay == "sun") dayOfWeeks.add(WeekDay.SUN)
                 }
                 return dayOfWeeks
             }

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/crawl/naver/NaverCrawlerService.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/crawl/naver/NaverCrawlerService.kt
@@ -3,6 +3,7 @@ package com.depromeet.webtoon.core.crawl.naver
 import com.depromeet.webtoon.core.application.imports.WebtoonImportService
 import com.depromeet.webtoon.core.application.imports.dto.WebtoonImportRequest
 import com.depromeet.webtoon.core.type.WebtoonSite
+import com.depromeet.webtoon.core.type.WeekDay
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
@@ -26,7 +27,7 @@ class NaverCrawlerService(
                 score = it.select("dl .rating_type strong").text().toDouble(),
                 thumbnailImage = it.select(".thumb img").attr("src"),
                 url = it.select("dl dt a").attr("href"),
-                dayOfWeeks = listOf(DayOfWeek.MONDAY),
+                dayOfWeeks = listOf(WeekDay.MON),
                 site = WebtoonSite.NAVER,
                 genres = listOf(),
                 popular = index

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/dto/WebtoonUpsertRequest.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/dto/WebtoonUpsertRequest.kt
@@ -2,13 +2,13 @@ package com.depromeet.webtoon.core.domain.webtoon.dto
 
 import com.depromeet.webtoon.core.domain.author.model.Author
 import com.depromeet.webtoon.core.type.WebtoonSite
-import java.time.DayOfWeek
+import com.depromeet.webtoon.core.type.WeekDay
 
 data class WebtoonUpsertRequest(
     val title: String,
     val site: WebtoonSite,
     val authors: List<Author>,
-    val dayOfWeeks: List<DayOfWeek>,
+    val dayOfWeeks: List<WeekDay>,
     val popularity: Int,
     val thumbnail: String
 )

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/model/Webtoon.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/model/Webtoon.kt
@@ -3,6 +3,7 @@ package com.depromeet.webtoon.core.domain.webtoon.model
 import com.depromeet.webtoon.core.domain.author.model.Author
 import com.depromeet.webtoon.core.type.WebtoonSite
 import com.depromeet.webtoon.core.type.WebtoonSite.NONE
+import com.depromeet.webtoon.core.type.WeekDay
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
@@ -27,7 +28,7 @@ class Webtoon constructor(
     title: String = "",
     site: WebtoonSite = NONE,
     authors: List<Author> = mutableListOf(),
-    weekdays: List<String> = mutableListOf(),
+    weekdays: List<WeekDay> = mutableListOf(),
     popularity: Int = 0,
     thumbnail: String = "",
     createdAt: LocalDateTime? = null,
@@ -37,7 +38,7 @@ class Webtoon constructor(
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "webtoon_id")
+    @Column(name = "id")
     var id: Long? = id
 
     @Column(name = "title")
@@ -51,8 +52,9 @@ class Webtoon constructor(
     var authors: MutableList<Author> = authors.toMutableList()
 
     @ElementCollection
-    @CollectionTable(name = "week_day", joinColumns = [JoinColumn(name = "webtoon_id")])
-    var weekdays: List<String> = weekdays.toMutableList()
+    @CollectionTable(name = "week_day", joinColumns = [JoinColumn(name = "id")])
+    @Enumerated(EnumType.STRING)
+    var weekdays: MutableList<WeekDay> = weekdays.toMutableList()
 
     @Column(name = "popularity")
     var popularity: Int = popularity

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonRepository.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonRepository.kt
@@ -2,6 +2,7 @@ package com.depromeet.webtoon.core.domain.webtoon.repository
 
 import com.depromeet.webtoon.core.domain.webtoon.model.Webtoon
 import com.depromeet.webtoon.core.type.WebtoonSite
+import com.depromeet.webtoon.core.type.WeekDay
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.DayOfWeek
@@ -10,5 +11,6 @@ import java.time.DayOfWeek
 interface WebtoonRepository : JpaRepository<Webtoon, Long> {
     fun findBySiteAndTitle(site: WebtoonSite, title: String): Webtoon?
 
-    fun findAllByWeekdaysOrderByPopularityAsc(weeks: String): List<Webtoon>?
+    // fun findAllByWeekdaysOrderByPopularityAsc(weeks: String): List<Webtoon>?
+    fun findAllByWeekdaysOrderByPopularityAsc(weekDay: WeekDay): List<Webtoon>
 }

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/service/WebtoonService.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/service/WebtoonService.kt
@@ -6,6 +6,7 @@ import com.depromeet.webtoon.core.domain.webtoon.dto.WebtoonUpsertRequest
 import com.depromeet.webtoon.core.domain.webtoon.dto.toWebtoonCreateResponseDto
 import com.depromeet.webtoon.core.domain.webtoon.model.Webtoon
 import com.depromeet.webtoon.core.domain.webtoon.repository.WebtoonRepository
+import com.depromeet.webtoon.core.type.WeekDay
 import org.springframework.stereotype.Service
 
 @Service
@@ -13,7 +14,7 @@ class WebtoonService(
     val webtoonRepository: WebtoonRepository
 ) {
 
-    fun getWeekdayWebtoons(weekDay: String): List<Webtoon>? {
+    fun getWeekdayWebtoons(weekDay: WeekDay): List<Webtoon> {
         return webtoonRepository.findAllByWeekdaysOrderByPopularityAsc(weekDay)
     }
 
@@ -37,7 +38,7 @@ class WebtoonService(
                 site = request.site
                 title = request.title
                 authors = request.authors.toMutableList()
-                weekdays = request.dayOfWeeks.map { it.name }.toMutableList()
+                weekdays = request.dayOfWeeks.toMutableList()
                 popularity = request.popularity
                 thumbnail = request.thumbnail
             }
@@ -48,7 +49,7 @@ class WebtoonService(
                 title = request.title,
                 site = request.site,
                 authors = request.authors,
-                weekdays = request.dayOfWeeks.map { it.name }.toMutableList(),
+                weekdays = request.dayOfWeeks.toMutableList(),
                 popularity = request.popularity,
                 thumbnail = request.thumbnail
             )

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/type/WebtoonSite.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/type/WebtoonSite.kt
@@ -1,7 +1,7 @@
 package com.depromeet.webtoon.core.type
 
-enum class WebtoonSite {
-    NAVER,
-    DAUM,
-    NONE,
+enum class WebtoonSite(val thumbnail: String) {
+    NAVER("http://testNaverThumbnail.test"),
+    DAUM("http://testDaumThumbnail.test"),
+    NONE(""),
 }

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/type/WeekDay.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/type/WeekDay.kt
@@ -1,0 +1,11 @@
+package com.depromeet.webtoon.core.type
+
+enum class WeekDay {
+    MON,
+    TUE,
+    WED,
+    THU,
+    FRI,
+    SAT,
+    SUN
+}


### PR DESCRIPTION
1. [x] 더미데이터 반환작업,
2. [x] 불필요한 API 제외, 
3. [x] Site data class 를 VO로 변경,
4. [x] WebtoonSite enum 이 자체로 thumnail url 가질 수 있도록 변경, 
5. [x] webtoon 엔티티 id column name 변경 ( webtoon_id -> id ),
6. [x] 요일별웹툰 데이터 부재시 null 반환에서 emptyList 반환으로 변경 