### PR TITLE
Feature/gh 73 recommand by genre

### DIFF
--- a/.run/WebtoonApiApplication.run.xml
+++ b/.run/WebtoonApiApplication.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="WebtoonApiApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <module name="webtoon.webtoon-api.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="com.depromeet.webtoon.api.WebtoonApiApplication" />
-    <option name="ACTIVE_PROFILES" value="local" />
+    <option name="ACTIVE_PROFILES" value="webtoon-local-test" />
     <option name="ALTERNATIVE_JRE_PATH" />
     <option name="SHORTEN_COMMAND_LINE" value="NONE" />
     <method v="2">

--- a/webtoon-api/src/integration-test/kotlin/com/depromeet/webtoon/api/webtoon/WebtoonDetailControllerTest.kt
+++ b/webtoon-api/src/integration-test/kotlin/com/depromeet/webtoon/api/webtoon/WebtoonDetailControllerTest.kt
@@ -59,7 +59,8 @@ class WebtoonDetailControllerTest(
                     WebtoonDetailResponse(
                         webtoon.convertToWebtoonResponse(),
                         ScoreResponse(webtoonRatingAvg.totalAverage!!, webtoonRatingAvg.totalStoryScore!!, webtoonRatingAvg.drawingAverage!!),
-                        comments = listOf(CommentDto(comment.content, comment.nickname))
+                        comments = listOf(CommentDto(comment.content, comment.nickname)),
+                        randomRecommendWebtoons = listOf(webtoon.convertToWebtoonResponse())
                     ).toString()
                 )
             }

--- a/webtoon-api/src/main/kotlin/com/depromeet/webtoon/api/endpoint/dto/WebtoonDetailResponse.kt
+++ b/webtoon-api/src/main/kotlin/com/depromeet/webtoon/api/endpoint/dto/WebtoonDetailResponse.kt
@@ -1,8 +1,10 @@
 package com.depromeet.webtoon.api.endpoint.dto
 
 import com.depromeet.webtoon.core.application.api.dto.WebtoonResponse
+import com.depromeet.webtoon.core.application.api.dto.convertToWebtoonResponses
 import com.depromeet.webtoon.core.domain.rating.dto.CommentDto
 import com.depromeet.webtoon.core.domain.rating.dto.ScoreDto
+import com.depromeet.webtoon.core.domain.webtoon.model.Webtoon
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
 
@@ -13,13 +15,17 @@ data class WebtoonDetailResponse(
     @ApiModelProperty(value = "toonietoonie평점")
     val toonieScore: ScoreResponse,
     @ApiModelProperty(value = "댓글")
-    val comments: List<CommentDto>
+    val comments: List<CommentDto>,
+    @ApiModelProperty(value = "랜덤 추천")
+    val randomRecommendWebtoons: List<WebtoonResponse>,
+
 )
 
-fun convertToWebtoonDetailResponse(webtoon: WebtoonResponse, scores: ScoreDto, comments: List<CommentDto>): WebtoonDetailResponse {
+fun convertToWebtoonDetailResponse(webtoon: WebtoonResponse, scores: ScoreDto, comments: List<CommentDto>, randomWebtoons: List<Webtoon>): WebtoonDetailResponse {
     return WebtoonDetailResponse(
         webtoon = webtoon,
         ScoreResponse(scores.totalScore!!, scores.storyScore!!, scores.drawingScore!!),
-        comments = comments
+        comments = comments,
+        randomRecommendWebtoons = randomWebtoons.convertToWebtoonResponses()
     )
 }

--- a/webtoon-api/src/main/kotlin/com/depromeet/webtoon/api/endpoint/webtoon/WebtoonListController.kt
+++ b/webtoon-api/src/main/kotlin/com/depromeet/webtoon/api/endpoint/webtoon/WebtoonListController.kt
@@ -6,7 +6,9 @@ import com.depromeet.webtoon.api.endpoint.dto.WebtoonSearchResponse
 import com.depromeet.webtoon.api.endpoint.dto.WebtoonWeekDayResponse
 import com.depromeet.webtoon.api.endpoint.webtoon.dto.AuthorWebtoonResponse
 import com.depromeet.webtoon.api.endpoint.webtoon.service.AuthorWebtoonService
+import com.depromeet.webtoon.core.application.api.dto.WebtoonResponse
 import com.depromeet.webtoon.core.application.api.dto.convertToWebtoonResponses
+import com.depromeet.webtoon.core.domain.webtoon.dto.WebtoonTop20Response
 import com.depromeet.webtoon.core.domain.webtoon.service.WebtoonSearchService
 import com.depromeet.webtoon.core.domain.webtoon.service.WebtoonService
 import com.depromeet.webtoon.core.type.WeekDay
@@ -28,6 +30,17 @@ class WebtoonListController(
     val webtoonSearchService: WebtoonSearchService,
 ) {
     private val log = LoggerFactory.getLogger(WebtoonListController::class.java)
+
+    @GetMapping("/{genre}")
+    fun findGenreTop20Webtoons(
+        @ApiParam("장르", required = true, example = "드라마")
+        @PathVariable(name = "genre")
+        genre: String
+    ): ApiResponse<WebtoonTop20Response> {
+        log.info("$genre 컨트롤러")
+        val top20 = webtoonService.getTop20WebtoonsByGenre(genre)
+        return ok(top20)
+    }
 
     @GetMapping("/author/{authorId}")
     fun findAuthorWebtoons(

--- a/webtoon-api/src/main/kotlin/com/depromeet/webtoon/api/endpoint/webtoon/service/WebtoonDetailService.kt
+++ b/webtoon-api/src/main/kotlin/com/depromeet/webtoon/api/endpoint/webtoon/service/WebtoonDetailService.kt
@@ -33,6 +33,8 @@ class WebtoonDetailService(
 
         val commentInfo = commentRepository.findTop5ByWebtoonOrderByCreatedAtDesc(foundWebtoon.get())
 
+        val randomWebtoons = webtoonRepository.findRandomWebtoons()
+
         if (ratingInfo != null) {
             val webtoonDetailResponse = convertToWebtoonDetailResponse(
                 foundWebtoon.get().convertToWebtoonResponse(),
@@ -41,7 +43,8 @@ class WebtoonDetailService(
                     ratingInfo.storyAverage,
                     ratingInfo.drawingAverage
                 ),
-                commentInfo!!.map { CommentDto(it.content, it.nickname) }
+                commentInfo!!.map { CommentDto(it.content, it.nickname) },
+                randomWebtoons
             )
             log.info("[WebtoonDetailService - getWebtoonDetail] webtoon[${id}] rating not exist")
             return ApiResponse.ok(webtoonDetailResponse)
@@ -53,7 +56,8 @@ class WebtoonDetailService(
                     0.0,
                     0.0
                 ),
-                commentInfo!!.map { CommentDto(it.content, it.nickname) }
+                commentInfo!!.map { CommentDto(it.content, it.nickname) },
+                randomWebtoons
             )
             log.info("[WebtoonDetailService - getWebtoonDetail] webtoon[${id}] rating exist")
             return ApiResponse.ok(webtoonDetailResponse)

--- a/webtoon-api/src/test/kotlin/com/depromeet/webtoon/api/endpoint/webtoon/service/WebtoonDetailServiceTest.kt
+++ b/webtoon-api/src/test/kotlin/com/depromeet/webtoon/api/endpoint/webtoon/service/WebtoonDetailServiceTest.kt
@@ -50,6 +50,7 @@ class WebtoonDetailServiceTest : FunSpec({
             every { webtoonRepository.findById(any()) } returns Optional.of(webtoon)
             every { webtoonRatingAverageRepository.findByWebtoon(any()) } returns ratingAverage
             every { commentRepository.findTop5ByWebtoonOrderByCreatedAtDesc(any()) } returns listOf(comment)
+            every { webtoonRepository.findRandomWebtoons() } returns emptyList()
 
 
             // when
@@ -58,15 +59,11 @@ class WebtoonDetailServiceTest : FunSpec({
             // then
             verify(exactly = 1) {
                 webtoonRepository.findById(1L)
-            }
-
-            verify(exactly = 1) {
                 webtoonRatingAverageRepository.findByWebtoon(webtoon)
+                commentRepository.findTop5ByWebtoonOrderByCreatedAtDesc(webtoon)
+                webtoonRepository.findRandomWebtoons()
             }
 
-            verify(exactly = 1) {
-                commentRepository.findTop5ByWebtoonOrderByCreatedAtDesc(webtoon)
-            }
 
             webtoonDetail.status.shouldBe(ApiResponseStatus.OK)
             webtoonDetail.data!!.webtoon.backgroundColor.shouldBe(webtoonFixture().backgroudColor)
@@ -97,6 +94,7 @@ class WebtoonDetailServiceTest : FunSpec({
             every { webtoonRepository.findById(any()) } returns Optional.of(webtoon)
             every { webtoonRatingAverageRepository.findByWebtoon(any()) } returns null
             every { commentRepository.findTop5ByWebtoonOrderByCreatedAtDesc(any()) } returns listOf(comment)
+            every { webtoonRepository.findRandomWebtoons() } returns emptyList()
 
             // when
             val webtoonDetail = webtoonDetailService.getWebtoonDetail(1L)
@@ -104,14 +102,9 @@ class WebtoonDetailServiceTest : FunSpec({
             // then
             verify(exactly = 1) {
                 webtoonRepository.findById(1L)
-            }
-
-            verify(exactly = 1) {
                 webtoonRatingAverageRepository.findByWebtoon(webtoon)
-            }
-
-            verify(exactly = 1) {
                 commentRepository.findTop5ByWebtoonOrderByCreatedAtDesc(webtoon)
+                webtoonRepository.findRandomWebtoons()
             }
 
             webtoonDetail.data!!.toonieScore.totalScore.shouldBe(0.0)
@@ -129,20 +122,16 @@ class WebtoonDetailServiceTest : FunSpec({
             every { webtoonRepository.findById(any()) } returns Optional.of(webtoon)
             every { webtoonRatingAverageRepository.findByWebtoon(any()) } returns ratingAverage
             every { commentRepository.findTop5ByWebtoonOrderByCreatedAtDesc(any()) } returns emptyList()
+            every { webtoonRepository.findRandomWebtoons() } returns emptyList()
 
             val webtoonDetail = webtoonDetailService.getWebtoonDetail(1L)
 
             // then
             verify(exactly = 1) {
                 webtoonRepository.findById(1L)
-            }
-
-            verify(exactly = 1) {
                 webtoonRatingAverageRepository.findByWebtoon(webtoon)
-            }
-
-            verify(exactly = 1) {
                 commentRepository.findTop5ByWebtoonOrderByCreatedAtDesc(webtoon)
+                webtoonRepository.findRandomWebtoons()
             }
 
             webtoonDetail.status.shouldBe(ApiResponseStatus.OK)

--- a/webtoon-api/src/test/kotlin/com/depromeet/webtoon/api/endpoint/webtoon/service/WebtoonDetailServiceTest.kt
+++ b/webtoon-api/src/test/kotlin/com/depromeet/webtoon/api/endpoint/webtoon/service/WebtoonDetailServiceTest.kt
@@ -27,6 +27,7 @@ class WebtoonDetailServiceTest : FunSpec({
     lateinit var commentRepository: CommentRepository
 
 
+    //todo RandomWebtoon
 
     beforeTest {
         webtoonRepository = mockk()

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/SampleRunner.java
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/SampleRunner.java
@@ -111,31 +111,10 @@ public class SampleRunner implements ApplicationRunner {
         int randomNumber = (int) (Math.random() * 10);
         // 장르 리스트에서
 
-        // Webtoon webtoonR = genreRecommend("드라마", randomNumber);
-        // System.out.println(webtoonR.getTitle());
         System.out.println("=====");
         webtoonRepository.findTop10ByGenresInAndSiteOrderByScoreDesc(List.of("드라마"),  WebtoonSite.NAVER).stream().forEach(w -> System.out.println(w.getTitle()));
         webtoonRepository.findTop10ByGenresInAndSiteOrderByScoreDesc(List.of("드라마"),  WebtoonSite.DAUM).stream().forEach(w -> System.out.println(w.getTitle()));
 
     }
 
-    /*private Webtoon genreRecommend(String genre, int radomNumber) {
-        System.out.println("========");
-        System.out.println(radomNumber);
-        if(radomNumber % 2 == 1){
-            switch (genre) {
-                case "드라마":
-                    return webtoonRepository.daumGenreRecommendQuery(genre, radomNumber);
-                default:
-                    return null;
-            }
-        } else {
-            switch (genre) {
-                case "드라마":
-                    return webtoonRepository.naverGenreRecommendQuery(genre, radomNumber);
-                default:
-                    return null;
-            }
-        }
-    }*/
 }

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/SampleRunner.java
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/SampleRunner.java
@@ -54,7 +54,7 @@ public class SampleRunner implements ApplicationRunner {
 
         // daumCrawlerService.updateCompletedDaumWebtoons();
         daumCrawlerService.updateDaumWebtoons();
-        // naverCrawlerService.crawlAndUpsert();
+        naverCrawlerService.crawlAndUpsert();
 
         Optional<Webtoon> webtoon = webtoonRepository.findById(1l);
 
@@ -108,32 +108,34 @@ public class SampleRunner implements ApplicationRunner {
 
 
         System.out.println("=====");
-        int randomNumber = (int) (Math.random() * 5);
+        int randomNumber = (int) (Math.random() * 10);
         // 장르 리스트에서
 
-        List<Webtoon> webtoons = genreRecommend("드라마", randomNumber);
-        webtoons.stream().forEach(w -> System.out.println(w.getTitle()));
+        // Webtoon webtoonR = genreRecommend("드라마", randomNumber);
+        // System.out.println(webtoonR.getTitle());
         System.out.println("=====");
-        webtoonRepository.findTop5ByGenresInAndScoreGreaterThanAndSite(List.of("드라마"), 9, WebtoonSite.NAVER).stream().forEach(w -> System.out.println(w.getTitle()));
-        webtoonRepository.findTop5ByGenresInAndScoreGreaterThanAndSite(List.of("드라마"), 9, WebtoonSite.DAUM).stream().forEach(w -> System.out.println(w.getTitle()));
+        webtoonRepository.findTop10ByGenresInAndSiteOrderByScoreDesc(List.of("드라마"),  WebtoonSite.NAVER).stream().forEach(w -> System.out.println(w.getTitle()));
+        webtoonRepository.findTop10ByGenresInAndSiteOrderByScoreDesc(List.of("드라마"),  WebtoonSite.DAUM).stream().forEach(w -> System.out.println(w.getTitle()));
 
     }
 
-    private List<Webtoon> genreRecommend(String genre, int radomNumber) {
+    /*private Webtoon genreRecommend(String genre, int radomNumber) {
+        System.out.println("========");
+        System.out.println(radomNumber);
         if(radomNumber % 2 == 1){
             switch (genre) {
                 case "드라마":
                     return webtoonRepository.daumGenreRecommendQuery(genre, radomNumber);
                 default:
-                    return List.of(new Webtoon());
+                    return null;
             }
         } else {
             switch (genre) {
                 case "드라마":
                     return webtoonRepository.naverGenreRecommendQuery(genre, radomNumber);
                 default:
-                    return List.of(new Webtoon());
+                    return null;
             }
         }
-    }
+    }*/
 }

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/application/api/home/GenreRecommendService.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/application/api/home/GenreRecommendService.kt
@@ -1,0 +1,32 @@
+package com.depromeet.webtoon.core.application.api.home
+
+import com.depromeet.webtoon.core.domain.webtoon.model.Webtoon
+import com.depromeet.webtoon.core.domain.webtoon.repository.WebtoonRepository
+import org.springframework.stereotype.Service
+
+@Service
+class GenreRecommendService (
+    val webtoonRepository: WebtoonRepository
+        ) {
+
+    fun getRecommendWebtoonByGenre(): List<Webtoon>{
+
+        val genreRecommendWebtoons = mutableListOf<Webtoon>()
+
+        GENRE.map {
+            // random 은 사이트별 TOP 10 중 랜덤한 상위 5개 웹툰 중에서 추천 해주기 위함
+            val random = (Math.random() * 5).toLong()
+            val optionalRecommendWebtoon = webtoonRepository.genreRecommendWebtoon(random, it)
+            if(optionalRecommendWebtoon != null){
+                genreRecommendWebtoons.add(optionalRecommendWebtoon)
+            }
+        }
+
+        return genreRecommendWebtoons
+    }
+
+    companion object {
+        private  val GENRE = listOf("드라마", "일상", "판타지", "액션", "순정")
+    }
+
+}

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/application/api/home/HomeApiService.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/application/api/home/HomeApiService.kt
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service
 class HomeApiService(
     val webtoonService: WebtoonService,
     val bannerService: BannerService,
+    val genreRecommendService: GenreRecommendService,
 ) {
     fun fetchHome(homeApiRequest: HomeApiRequest): HomeApiResponse {
         val sampleWebtoons = webtoonService.getWeekdayWebtoons(WeekDay.MON)
@@ -25,11 +26,15 @@ class HomeApiService(
             bannerService.searchBanners(it).convertToBannerResponses()
         }
 
+        val genreWebtoons = genreRecommendService.getRecommendWebtoonByGenre()
+            .convertToWebtoonResponses()
+
+
         return HomeApiResponse(
             mainBanner = homeMainBanners,
             weekdayWebtoons = sampleWebtoons,
             trendingWebtons = sampleWebtoons,
-            genreWebtoons = sampleWebtoons,
+            genreWebtoons = genreWebtoons,
             bingeWatchableWebtoons = sampleWebtoons,
         )
     }

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/comment/repository/CommentCustomRepositoryImpl.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/comment/repository/CommentCustomRepositoryImpl.kt
@@ -15,6 +15,7 @@ class CommentCustomRepositoryImpl(@Autowired private val entityManger: EntityMan
     private val query = JPAQueryFactory(entityManger)
 
 
+
     override fun getComments(webtoonId: Long, commentId: Long?, pageSize: Long): List<Comment> {
         val dynamicLtId = BooleanBuilder()
 

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/dto/WebtoonTop20Response.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/dto/WebtoonTop20Response.kt
@@ -1,0 +1,16 @@
+package com.depromeet.webtoon.core.domain.webtoon.dto
+
+import com.depromeet.webtoon.core.application.api.dto.WebtoonResponse
+import io.swagger.annotations.ApiModel
+import io.swagger.annotations.ApiModelProperty
+
+
+@ApiModel("장르별 탑20 반환 데이터")
+data class WebtoonTop20Response (
+    @ApiModelProperty("장르")
+    val genre: String,
+    @ApiModelProperty("TOP20 웹툰 리스트")
+    val top20Webtoons: List<WebtoonResponse>,
+
+
+)

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonCustomRepository.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonCustomRepository.kt
@@ -6,5 +6,7 @@ interface WebtoonCustomRepository {
     fun fetchForAdmin(page: Int, pageSize: Int): List<Webtoon>
     fun fetchCountForAdmin(): Long
     fun genreRecommendWebtoon(random: Long, genre: String): Webtoon?
+    fun get_Top10_Naver_Webtoons_ByGenre(genre: String): List<Webtoon>
+    fun get_Top10_Daum_Webtoons_ByGenre(genre: String): List<Webtoon>
 
 }

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonCustomRepository.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonCustomRepository.kt
@@ -5,4 +5,6 @@ import com.depromeet.webtoon.core.domain.webtoon.model.Webtoon
 interface WebtoonCustomRepository {
     fun fetchForAdmin(page: Int, pageSize: Int): List<Webtoon>
     fun fetchCountForAdmin(): Long
+    fun genreRecommendWebtoon(random: Long, genre: String): Webtoon?
+
 }

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonCustomRepositoryImpl.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonCustomRepositoryImpl.kt
@@ -1,13 +1,47 @@
 package com.depromeet.webtoon.core.domain.webtoon.repository
 
 import com.depromeet.webtoon.core.domain.webtoon.model.QWebtoon
+import com.depromeet.webtoon.core.domain.webtoon.model.QWebtoon.webtoon
 import com.depromeet.webtoon.core.domain.webtoon.model.Webtoon
+import com.depromeet.webtoon.core.type.WebtoonSite
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.Predicate
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.hibernate.Hibernate
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
 import org.springframework.transaction.annotation.Transactional
+import javax.persistence.EntityManager
 
 @Transactional
-class WebtoonCustomRepositoryImpl() : WebtoonCustomRepository, QuerydslRepositorySupport(Webtoon::class.java) {
+class WebtoonCustomRepositoryImpl(entityManger: EntityManager) : WebtoonCustomRepository, QuerydslRepositorySupport(Webtoon::class.java) {
+
+    private val query = JPAQueryFactory(entityManger)
+
+    override fun genreRecommendWebtoon(random: Long, genres: String):Webtoon? {
+        val dynamicSite = BooleanBuilder()
+        // 두가지 사이트를 섞어서 보여주기 위함
+        if(random.toInt() % 2 == 0){
+            dynamicSite.and(webtoon.site.eq(WebtoonSite.NAVER))
+        } else(
+            dynamicSite.and(webtoon.site.eq(WebtoonSite.DAUM))
+        )
+
+        return query
+            .selectFrom(webtoon)
+            .where(webtoonGenreEq(genres), dynamicSite)
+            .orderBy(webtoon.score.desc())
+            .offset(random)
+            .limit(1)
+            .fetchOne()
+    }
+
+    private fun webtoonGenreEq(genres: String): Predicate? {
+        if(genres == "순정"){
+            return (webtoon.genres.contains("로맨스").and(webtoon.genres.contains("스토리"))).or(webtoon.genres.contains("순정"))
+        } else {
+            return webtoon.genres.contains(genres)
+        }
+    }
 
     override fun fetchForAdmin(page: Int, pageSize: Int): List<Webtoon> {
         return entityManager!!.createQuery("SELECT w FROM Webtoon AS w ORDER BY w.id DESC", Webtoon::class.java)
@@ -21,6 +55,6 @@ class WebtoonCustomRepositoryImpl() : WebtoonCustomRepository, QuerydslRepositor
     }
 
     override fun fetchCountForAdmin(): Long {
-        return from(QWebtoon.webtoon).fetchCount()
+        return from(webtoon).fetchCount()
     }
 }

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonCustomRepositoryImpl.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonCustomRepositoryImpl.kt
@@ -17,6 +17,27 @@ class WebtoonCustomRepositoryImpl(entityManger: EntityManager) : WebtoonCustomRe
 
     private val query = JPAQueryFactory(entityManger)
 
+
+    override fun get_Top10_Naver_Webtoons_ByGenre(genre: String): List<Webtoon> {
+        return query
+            .selectFrom(webtoon)
+            .where(webtoonGenreEq(genre), webtoon.site.eq(WebtoonSite.NAVER))
+            .orderBy(webtoon.score.desc())
+            .offset(1L)
+            .limit(10)
+            .fetch()
+    }
+
+    override fun get_Top10_Daum_Webtoons_ByGenre(genre: String): List<Webtoon> {
+        return query
+            .selectFrom(webtoon)
+            .where(webtoonGenreEq(genre), webtoon.site.eq(WebtoonSite.DAUM))
+            .orderBy(webtoon.score.desc())
+            .offset(1L)
+            .limit(10)
+            .fetch()
+    }
+
     override fun genreRecommendWebtoon(random: Long, genres: String):Webtoon? {
         val dynamicSite = BooleanBuilder()
         // 두가지 사이트를 섞어서 보여주기 위함

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonRepository.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonRepository.kt
@@ -34,4 +34,14 @@ interface WebtoonRepository : JpaRepository<Webtoon, Long>, WebtoonCustomReposit
         genres: List<String>,
         site: WebtoonSite
     ): List<Webtoon>
+
+    @Query(
+        """
+            select * from webtoon w
+            order by rand()
+            limit 3
+        """,
+        nativeQuery = true
+    )
+    fun findRandomWebtoons():List<Webtoon>
 }

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonRepository.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/repository/WebtoonRepository.kt
@@ -29,35 +29,9 @@ interface WebtoonRepository : JpaRepository<Webtoon, Long>, WebtoonCustomReposit
     )
     fun searchByQuery(text: String): List<Webtoon>
 
-    @Query(
-        """
-        select * from webtoon w
-            left outer join webtoon_genre g on w.id=g.webtoon_id
-        where( g.genre in (?) )
-        and w.score>9
-        and w.site = 'DAUM'
-        limit ?,1
-        """,
-        nativeQuery = true
-    )
-    fun daumGenreRecommendQuery(genres: String, randomRow: Int): List<Webtoon>
 
-    @Query(
-        """
-        select * from webtoon w
-            left outer join webtoon_genre g on w.id=g.webtoon_id
-        where( g.genre in (?) )
-        and w.score>9
-        and w.site = 'NAVER'
-        limit ?,1
-        """,
-        nativeQuery = true
-    )
-    fun naverGenreRecommendQuery(genre: String, randomRow: Int): List<Webtoon>
-
-    fun findTop5ByGenresInAndScoreGreaterThanAndSite(
+    fun findTop10ByGenresInAndSiteOrderByScoreDesc(
         genres: List<String>,
-        score: Double,
         site: WebtoonSite
     ): List<Webtoon>
 }

--- a/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/service/WebtoonService.kt
+++ b/webtoon-core/src/main/kotlin/com/depromeet/webtoon/core/domain/webtoon/service/WebtoonService.kt
@@ -1,18 +1,34 @@
 package com.depromeet.webtoon.core.domain.webtoon.service
 
+import com.depromeet.webtoon.core.application.api.dto.convertToWebtoonResponse
+import com.depromeet.webtoon.core.application.api.dto.convertToWebtoonResponses
 import com.depromeet.webtoon.core.domain.webtoon.dto.WebtoonCreateRequest
 import com.depromeet.webtoon.core.domain.webtoon.dto.WebtoonCreateResponseDto
+import com.depromeet.webtoon.core.domain.webtoon.dto.WebtoonTop20Response
 import com.depromeet.webtoon.core.domain.webtoon.dto.WebtoonUpsertRequest
 import com.depromeet.webtoon.core.domain.webtoon.dto.toWebtoonCreateResponseDto
 import com.depromeet.webtoon.core.domain.webtoon.model.Webtoon
 import com.depromeet.webtoon.core.domain.webtoon.repository.WebtoonRepository
 import com.depromeet.webtoon.core.type.WeekDay
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class WebtoonService(
     val webtoonRepository: WebtoonRepository
 ) {
+    private val log = LoggerFactory.getLogger(WebtoonService::class.java)
+
+    fun getTop20WebtoonsByGenre(genre: String): WebtoonTop20Response {
+        log.info("$genre service")
+        val top20 = mutableListOf<Webtoon>()
+        top20.addAll(webtoonRepository.get_Top10_Naver_Webtoons_ByGenre(genre))
+        top20.addAll(webtoonRepository.get_Top10_Daum_Webtoons_ByGenre(genre))
+        return WebtoonTop20Response(
+            genre = genre,
+            top20Webtoons = top20.convertToWebtoonResponses()
+        )
+    }
 
     fun findById(id: Long): Webtoon {
         return webtoonRepository.findById(id)
@@ -74,4 +90,6 @@ class WebtoonService(
             }
         }
     }
+
+
 }


### PR DESCRIPTION
홈화면에서 보여줄 추천웹툰 로직구현

장르별 웹툰의 평점 상위 5개 중 1개를 랜덤으로 뽑아 장르별로 1개씩 총 5개의 웹툰리스트를 생성해 response 합니다.
장르별 웹툰리스트의 각각의 웹툰 플랫폼은  '네이버', '다음' 중 랜덤으로 선택됩니다. 
네이버 웹툰의 경우 '순정' 장르는 '로맨스' & '스토리' 가 함께 있는 경우 '순정' 장르에 속합니다. 
-> 네이버 웹툰의 장르별 추천에서 '순정' 에 해당하는 웹툰들 역시 '로맨스' 와 '스토리' 가 함께 있는 웹툰이여서 위와 같이 설정하였습니다.

--ex)
1. 드라마장르 ( 네이버 '드라마웹툰' ) 
2. 일상장르 ( 네이버 '일상웹툰' )
3. 판타지장르 ( 다음 '판타지웹툰')  
4. 액션장르 ( 다음 '액션웹툰' )
5. 순정장르 ( 네이버 '로맨스&&스토리 웹툰' ) 
